### PR TITLE
Fix download link placeholders with correct GitHub username

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Designed and built by Beau Lewis.
 
 ## 🎯 Quick Download (No Installation Required!) - v2.1.0
 
-### 📦 **[Download Windows Complete Package → One-Click Install!](https://github.com/yourusername/universal-document-converter/releases/latest/download/Universal-Document-Converter-v2.1.0-Windows-Complete.zip)**
+### 📦 **[Download Windows Complete Package → One-Click Install!](https://github.com/Beaulewis1977/quick_ocr_doc_converter/releases/latest/download/Universal-Document-Converter-v2.1.0-Windows-Complete.zip)**
 
 🆕 **NEW v2.1.0 Features:**
 - ✨ **Bidirectional Markdown ↔ RTF conversion**
@@ -29,7 +29,7 @@ Designed and built by Beau Lewis.
 ---
 
 ### 🖥️ **Alternative: Standalone Executable**
-**[Download Universal-Document-Converter-v2.1.0.exe](https://github.com/yourusername/universal-document-converter/releases/latest/download/Universal-Document-Converter-v2.1.0.exe)**
+**[Download Universal-Document-Converter-v2.1.0.exe](https://github.com/Beaulewis1977/quick_ocr_doc_converter/releases/latest/download/Universal-Document-Converter-v2.1.0.exe)**
 
 🆕 **Self-contained executable with all Markdown features:**
 - ✨ **NEW: Markdown → RTF/HTML/TXT/EPUB/DOCX/PDF conversion** 
@@ -44,13 +44,13 @@ Designed and built by Beau Lewis.
 ---
 
 ### 🍎 **macOS & 🐧 Linux Users**
-**[Download Source ZIP](https://github.com/yourusername/universal-document-converter/releases/latest/download/Universal-Document-Converter-v2.1.0-Source.zip)**
+**[Download Source ZIP](https://github.com/Beaulewis1977/quick_ocr_doc_converter/releases/latest/download/Universal-Document-Converter-v2.1.0-Source.zip)**
 
 🆕 **v2.1.0 with full Markdown support:**
 ```bash
 # Extract the ZIP file
 unzip Universal-Document-Converter-v2.1.0-Source.zip
-cd universal-document-converter
+cd quick_ocr_doc_converter
 
 # Install dependencies (includes new Markdown libraries)
 pip install -r requirements.txt

--- a/RELEASE_READY_SUMMARY.md
+++ b/RELEASE_READY_SUMMARY.md
@@ -74,19 +74,19 @@ This creates in the `releases/` folder:
    - Upload both ZIP files from `releases/` folder
 
 3. **Update README links:**
-   - Replace `yourusername` with actual GitHub username
+   - ✅ All GitHub username placeholders updated to `Beaulewis1977`
    - Links will automatically point to latest release
 
 ### 🔗 Direct Download Links (after release):
 
 Windows ZIP:
 ```
-https://github.com/[username]/universal-document-converter/releases/latest/download/UniversalDocumentConverter_Windows_2.0.0_Installer.zip
+https://github.com/Beaulewis1977/quick_ocr_doc_converter/releases/latest/download/UniversalDocumentConverter_Windows_2.0.0_Installer.zip
 ```
 
 Source ZIP:
 ```
-https://github.com/[username]/universal-document-converter/releases/latest/download/UniversalDocumentConverter_Source_2.0.0.zip
+https://github.com/Beaulewis1977/quick_ocr_doc_converter/releases/latest/download/UniversalDocumentConverter_Source_2.0.0.zip
 ```
 
 ### ✨ User Experience:

--- a/universal_document_converter_ultimate.py
+++ b/universal_document_converter_ultimate.py
@@ -1279,7 +1279,7 @@ with open('output.txt', 'wb') as f:
     
     def show_documentation(self):
         """Show application documentation"""
-        webbrowser.open("https://github.com/yourusername/universal-document-converter/wiki")
+        webbrowser.open("https://github.com/Beaulewis1977/quick_ocr_doc_converter/wiki")
     
     def show_api_documentation(self):
         """Show API documentation"""


### PR DESCRIPTION
## Summary
- Replaced all placeholder GitHub usernames (`yourusername`) with the actual username `Beaulewis1977` in README.md, RELEASE_READY_SUMMARY.md, and universal_document_converter_ultimate.py
- Updated download links to point to the correct repository `quick_ocr_doc_converter` for Windows, macOS, Linux, and executable downloads
- Fixed directory name in README instructions from `universal-document-converter` to `quick_ocr_doc_converter`
- Corrected the documentation URL in the application to open the correct GitHub wiki page

## Changes

### Documentation and Links
- **README.md**: Updated all download links to use the correct GitHub username and repository name
- **RELEASE_READY_SUMMARY.md**: Confirmed all username placeholders replaced with `Beaulewis1977` and updated example download URLs

### Code
- **universal_document_converter_ultimate.py**: Fixed the web browser documentation link to point to the correct GitHub wiki URL

## Test plan
- [x] Verified all download links in README.md redirect correctly to the latest release assets
- [x] Confirmed the documentation link opens the correct GitHub wiki page
- [x] Checked README instructions for correct directory names and commands
- [x] Reviewed RELEASE_READY_SUMMARY.md for accurate username replacements

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/25a47a06-a8cf-4b95-8858-4c272c89aa49